### PR TITLE
upgrading gulp-sass to 2.2.0 to make recipe work on node 4 or higher

### DIFF
--- a/recipes/gulp.sass/package.json
+++ b/recipes/gulp.sass/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "browser-sync": "^2.2.0",
     "gulp": "^3.8.11",
-    "gulp-sass": "^1.3.3"
+    "gulp-sass": "^2.2.0"
   }
 }


### PR DESCRIPTION
Hey guys,

The Gulp + SASS recipe doesn't work for node 4 or higher and it is due to the gulp-sass plugin which was outdated. This PR fixes that.

