### PR TITLE
Add recipe for injecting a local css file into a BrowserSync proxied page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -290,6 +290,28 @@
         "title": "Middleware Css Injection"
     },
     {
+        "dir": "proxy.custom-css",
+        "name": [
+            "proxy",
+            "custom-css"
+        ],
+        "pkg": {
+            "name": "bs-recipes-server",
+            "version": "1.0.0",
+            "description": "Proxy example + injecting custom css file",
+            "main": "app.js",
+            "scripts": {
+                "start": "node app.js"
+            },
+            "license": "MIT",
+            "dependencies": {
+                "browser-sync": "^2.1.6"
+            }
+        },
+        "link": "https://github.com/Browsersync/recipes/tree/master/recipes/proxy.custom-css",
+        "title": "Proxy Custom-css"
+    },
+    {
         "dir": "server",
         "name": [
             "server"

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ Here's what we have currently...
 - [Gulp, SASS + Slow running tasks](https://github.com/Browsersync/recipes/tree/master/recipes/gulp.task.sequence)
 - [HTML/CSS injection example](https://github.com/Browsersync/recipes/tree/master/recipes/html.injection)
 - [Middleware + CSS example](https://github.com/Browsersync/recipes/tree/master/recipes/middleware.css.injection)
+- [Proxy example + injecting custom css file](https://github.com/Browsersync/recipes/tree/master/recipes/proxy.custom-css)
 - [Server example](https://github.com/Browsersync/recipes/tree/master/recipes/server)
 - [Server with pre-gzipped assets example](https://github.com/Browsersync/recipes/tree/master/recipes/server.gzipped.assets)
 - [Server includes example](https://github.com/Browsersync/recipes/tree/master/recipes/server.includes)

--- a/recipes/proxy.custom-css/app.js
+++ b/recipes/proxy.custom-css/app.js
@@ -1,0 +1,22 @@
+/**
+ * Require Browsersync
+ */
+var browserSync = require('browser-sync');
+
+/**
+ * Run Browsersync with server config
+ * You can use an arrays for files to specify multiple files
+ */
+browserSync({
+    proxy: "example.com",
+    serveStatic: [ 'app/static' ],
+    files: "app/static/_custom.css",
+    snippetOptions: {
+        rule: {
+            match: /<\/head>/i,
+            fn: function (snippet, match) {
+                return '<link rel="stylesheet" type="text/css" href="/_custom.css"/>' + snippet + match;
+            }
+        }
+    }
+});

--- a/recipes/proxy.custom-css/app/static/_custom.css
+++ b/recipes/proxy.custom-css/app/static/_custom.css
@@ -1,0 +1,3 @@
+body {
+    background: black;
+}

--- a/recipes/proxy.custom-css/desc.md
+++ b/recipes/proxy.custom-css/desc.md
@@ -1,0 +1,2 @@
+
+To see the live-updating and CSS injecting, simply perform changes to `app/static/_custom.css`

--- a/recipes/proxy.custom-css/package.json
+++ b/recipes/proxy.custom-css/package.json
@@ -8,6 +8,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "browser-sync": "^2.1.6"
+    "browser-sync": "^2.11.2"
   }
 }

--- a/recipes/proxy.custom-css/package.json
+++ b/recipes/proxy.custom-css/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bs-recipes-server",
+  "version": "1.0.0",
+  "description": "Proxy example + injecting custom css file",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "browser-sync": "^2.1.6"
+  }
+}

--- a/recipes/proxy.custom-css/readme.md
+++ b/recipes/proxy.custom-css/readme.md
@@ -1,0 +1,58 @@
+#Browsersync - Proxy example + injecting custom css file
+
+## Installation/Usage:
+
+To try this example, follow these 4 simple steps. 
+
+**Step 1**: Clone this entire repo
+```bash
+$ git clone https://github.com/Browsersync/recipes.git bs-recipes
+```
+
+**Step 2**: Move into the directory containing this example
+```bash
+$ cd bs-recipes/recipes/proxy.custom-css
+```
+
+**Step 3**: Install dependencies
+```bash
+$ npm install
+```
+
+**Step 4**: Run the example
+```bash
+$ npm start
+```
+
+### Additional Info:
+
+
+
+To see the live-updating and CSS injecting, simply perform changes to `app/static/_custom.css`
+
+### Preview of `app.js`:
+```js
+/**
+ * Require Browsersync
+ */
+var browserSync = require('browser-sync');
+
+/**
+ * Run Browsersync with server config
+ * You can use arrays for serveStatic and files to specify multiple files/directories
+ */
+browserSync({
+    proxy: "example.com",
+    serveStatic: 'app/static',
+    files: "app/static/_custom.css",
+    snippetOptions: {
+        rule: {
+            match: /<\/head>/i,
+            fn: function (snippet, match) {
+                return '<link rel="stylesheet" type="text/css" href="/_custom.css"/>' + snippet + match;
+            }
+        }
+    }
+});
+```
+


### PR DESCRIPTION
The recipe shows how to inject a local css file into a remote page using BrowserSync's proxy mode. I find this useful for modifying a design of a given page with all the advantages of BrowserSync.

Greets,
Max