### PR TITLE
Using post 2.0.0 recommended browser-sync syntax

### DIFF
--- a/recipes/gulp.sass/gulpfile.js
+++ b/recipes/gulp.sass/gulpfile.js
@@ -1,7 +1,6 @@
 var gulp        = require('gulp');
-var browserSync = require('browser-sync');
+var browserSync = require('browser-sync').create();
 var sass        = require('gulp-sass');
-var reload      = browserSync.reload;
 
 var src = {
     scss: 'app/scss/*.scss',
@@ -12,12 +11,12 @@ var src = {
 // Static Server + watching scss/html files
 gulp.task('serve', ['sass'], function() {
 
-    browserSync({
+    browserSync.init({
         server: "./app"
     });
 
     gulp.watch(src.scss, ['sass']);
-    gulp.watch(src.html).on('change', reload);
+    gulp.watch(src.html).on('change', browserSync.reload);
 });
 
 // Compile sass into CSS


### PR DESCRIPTION
Pre 2.0.0 sytax was:
```
var browserSync = require("browser-sync");
browserSync({server: "./app"});
```
Newer *recommended* syntax (see https://www.browsersync.io/docs/api/):
```
var browserSync = require("browser-sync").create();
browserSync.init({server: "./app"});
```