### PR TITLE
Add .gitignore for node_modules

### DIFF
--- a/recipes/webpack.babel/.gitignore
+++ b/recipes/webpack.babel/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
If you're using this recipe as a basis for a new project you're versioning, it's handy to have node_modules ignored from the outset.