### PR TITLE
Sync readme.md and gulpfile.js for gulp.sass recipe

### DIFF
--- a/recipes/gulp.sass/gulpfile.js
+++ b/recipes/gulp.sass/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp        = require('gulp');
 var browserSync = require('browser-sync').create();
 var sass        = require('gulp-sass');
+var reload      = browserSync.reload;
 
 var src = {
     scss: 'app/scss/*.scss',
@@ -16,7 +17,7 @@ gulp.task('serve', ['sass'], function() {
     });
 
     gulp.watch(src.scss, ['sass']);
-    gulp.watch(src.html).on('change', browserSync.reload);
+    gulp.watch(src.html).on('change', reload);
 });
 
 // Compile sass into CSS

--- a/recipes/gulp.sass/readme.md
+++ b/recipes/gulp.sass/readme.md
@@ -35,7 +35,7 @@ as the support for calling `reload` directly following html changes.
 ### Preview of `gulpfile.js`:
 ```js
 var gulp        = require('gulp');
-var browserSync = require('browser-sync');
+var browserSync = require('browser-sync').create();
 var sass        = require('gulp-sass');
 var reload      = browserSync.reload;
 
@@ -48,7 +48,7 @@ var src = {
 // Static Server + watching scss/html files
 gulp.task('serve', ['sass'], function() {
 
-    browserSync({
+    browserSync.init({
         server: "./app"
     });
 


### PR DESCRIPTION
Somebody on StackOverflow ran into a problem with the `gulp.sass` recipe:

http://stackoverflow.com/q/38302512/5892036

Turns out commit 331450b869f8d9f0104e82815bbbbb2adefab382 accidentally deleted the line that imports the `reload()` function. That commit also didn't update the [`readme.md`](https://github.com/BrowserSync/recipes/blob/master/recipes/gulp.sass/readme.md) file accordingly so `readme.md` and [`gulpfile.js`](https://github.com/BrowserSync/recipes/blob/master/recipes/gulp.sass/gulpfile.js) didn't match up.

This pull request syncs up both files and fixes the undefined `reload` problem.