### PR TITLE
chore: Add comment about watchify.args

### DIFF
--- a/recipes/gulp.browserify/readme.md
+++ b/recipes/gulp.browserify/readme.md
@@ -42,8 +42,10 @@ var exorcist    = require('exorcist');
 var browserify  = require('browserify');
 var browserSync = require('browser-sync').create();
 
-// Input file.
+// Watchify args contains necessary cache options to achieve fast incremental bundles.
+// See watchify readme for details. Adding debug true for sourcemap generation.
 watchify.args.debug = true;
+// Input file.
 var bundler = watchify(browserify('./app/js/app.js', watchify.args));
 
 // Babel transform


### PR DESCRIPTION
I was wondering why my bundle operation was super slow and I realized that I removed watchify.args, because I didn't know that they were needed until I read about them on the watchify README.