### PR TITLE
Update Deps For 2 Recipes

### DIFF
--- a/recipes/webpack.react-hot-loader/.babelrc
+++ b/recipes/webpack.react-hot-loader/.babelrc
@@ -1,0 +1,3 @@
+{
+	"presets": ["react", "es2015"]
+}

--- a/recipes/webpack.react-hot-loader/app/js/HelloWorld.jsx
+++ b/recipes/webpack.react-hot-loader/app/js/HelloWorld.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class HelloWorld extends React.Component {
+export default class HelloWorld extends Component {
   render() {
     // Play with it...
     const name = 'World';

--- a/recipes/webpack.react-hot-loader/app/js/main.js
+++ b/recipes/webpack.react-hot-loader/app/js/main.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { render } from 'react-dom';
 // It's important to not define HelloWorld component right in this file
 // because in that case it will do full page reload on change
 import HelloWorld from './HelloWorld.jsx';
 
-React.render(<HelloWorld />, document.getElementById('react-root'));
+render(<HelloWorld />, document.getElementById('react-root'));

--- a/recipes/webpack.react-hot-loader/package.json
+++ b/recipes/webpack.react-hot-loader/package.json
@@ -9,13 +9,16 @@
     "start": "node ."
   },
   "dependencies": {
-    "babel-core": "^5.8.9",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.16.0",
     "browser-sync": "^2.8.0",
-    "react": "^0.13.3",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "react-hot-loader": "^1.2.8",
     "webpack": "^1.10.5",
     "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^1.1.0"
+    "webpack-hot-middleware": "^2.13.2"
   }
 }

--- a/recipes/webpack.react-transform-hmr/.babelrc
+++ b/recipes/webpack.react-transform-hmr/.babelrc
@@ -1,22 +1,21 @@
 // Source:
 // https://github.com/gaearon/react-transform-hmr/tree/f22f9a938ed295e0c5ebe756d73fdae4c3a6fdef
 {
+  "presets": ["react", "es2015"],
   "env": {
     // only enable it when process.env.NODE_ENV is 'development' or undefined
     "development": {
-      "plugins": ["react-transform"],
-      "extra": {
-        // must be defined and be an array
-        "react-transform": [{
-          "target": "react-transform-hmr",
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+          "transform": "react-transform-hmr",
           // if you use React Native, pass "react-native" instead:
           "imports": ["react"],
           // this is important for Webpack HMR:
           "locals": ["module"]
+          }]
         }]
-        // note: you can put more transforms into array
-        // this is just one of them!
-      }
+      ]
     }
   }
 }

--- a/recipes/webpack.react-transform-hmr/app/js/HelloWorld.jsx
+++ b/recipes/webpack.react-transform-hmr/app/js/HelloWorld.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class HelloWorld extends React.Component {
+export default class HelloWorld extends Component {
   render() {
     // Play with it...
     const name = 'World';

--- a/recipes/webpack.react-transform-hmr/app/js/main.js
+++ b/recipes/webpack.react-transform-hmr/app/js/main.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { render } from 'react-dom';
 // It's important to not define HelloWorld component right in this file
 // because in that case it will do full page reload on change
 import HelloWorld from './HelloWorld.jsx';
 
-React.render(<HelloWorld />, document.getElementById('react-root'));
+render(<HelloWorld />, document.getElementById('react-root'));

--- a/recipes/webpack.react-transform-hmr/package.json
+++ b/recipes/webpack.react-transform-hmr/package.json
@@ -9,14 +9,17 @@
     "start": "node ."
   },
   "dependencies": {
-    "babel-core": "^5.8.9",
-    "babel-loader": "^5.3.2",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-plugin-react-transform": "^2.0.2",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.16.0",
     "browser-sync": "^2.8.0",
-    "react": "^0.13.3",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "react-transform-hmr": "^1.0.0",
     "webpack": "^1.10.5",
     "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^1.1.0"
+    "webpack-hot-middleware": "^2.13.2"
   }
 }


### PR DESCRIPTION
Update Dependencies for 2 recipes:

`webpack.react-transform-hmr`  and `webpack.react-hot-loader`.
 
Mainly updated from Babel 5 => 6, React 0.x => 15.  The syntax for files like `.babelrc` changed slightly because of breaking changes for dependencies.  