### PR TITLE
delete dead link to Jade

### DIFF
--- a/recipes/gulp.pug/desc.md
+++ b/recipes/gulp.pug/desc.md
@@ -1,9 +1,6 @@
-This is an upgraded version of [gulp.jade recipe](https://github.com/Browsersync/recipes/tree/master/recipes/gulp.jade) from [BrowserSync](https://github.com/browsersync/browser-sync) .
-
 Some useful links:
 
   - template engine : [pug documentation](https://pugjs.org/api/reference.html)
-    (was: Jade)
     - and its integration with gulp: [gulp-pug](https://www.npmjs.com/package/gulp-pug)
   - css preprocessing : [node-sass](https://www.npmjs.com/package/node-sass)
     - and its integration with


### PR DESCRIPTION
Also, there is a dead link at https://browsersync.io/docs/recipes where it references Gulp Jade. It should point to Gulp Pug.