### PR TITLE
Corrected link to gulp-sass

### DIFF
--- a/recipes/gulp.pug/readme.md
+++ b/recipes/gulp.pug/readme.md
@@ -35,7 +35,7 @@ Some useful links:
     - and its integration with gulp: [gulp-pug](https://www.npmjs.com/package/gulp-pug)
   - css preprocessing : [node-sass](https://www.npmjs.com/package/node-sass)
     - and its integration with
-      gulp: [gulp-sass](https://www.npmjs.com/package/gulp-pug)
+      gulp: [gulp-sass](https://www.npmjs.com/package/gulp-sass)
   - and of course [gulp](https://github.com/gulpjs/gulp/blob/master/docs/README.md)
 
 ### Preview of `gulpfile.js`:


### PR DESCRIPTION
The gulp-sass link was going to the gulp-pug page; I changed this to point to the gulp-sass page.